### PR TITLE
Sane default URL for adapter(s). Removes API_HOST_PROXY.

### DIFF
--- a/addon/adapters/application.js
+++ b/addon/adapters/application.js
@@ -32,11 +32,22 @@ export default Ember.Object.extend(FetchMixin, Evented, {
   /**
     The url for the entity, e.g. /posts or /api/v1/posts
 
+    defaults to config.APP.API_HOST/config.APP.API_PATH/pluralize(type) if
+    not set explicitly.
+
     @property url
     @type String
     @required
   */
-  url: null,
+  url: Ember.computed('type', {
+    get() {
+      const config = this.container.lookupFactory('config:environment');
+      const enclosingSlashes = /^\/|\/$/g;
+      const host = config.APP.API_HOST.replace(enclosingSlashes, '');
+      const path = config.APP.API_PATH.replace(enclosingSlashes, '');
+      return [host, path, pluralize(this.get('type'))].join('/');
+    }
+  }),
 
   /**
     Find resource(s) using an id or a using a query `{id: '', query: {}}`

--- a/blueprints/jsonapi-adapter/files/__root__/__path__/__name__.js
+++ b/blueprints/jsonapi-adapter/files/__root__/__path__/__name__.js
@@ -2,4 +2,6 @@
 
 export default <%= baseClass %>.extend({
   type: '<%= entity %>',
+
+  url: [config.APP.API_HOST, config.APP.API_PATH, '<%= resource %>'].join('/')
 });

--- a/blueprints/jsonapi-adapter/files/__root__/__path__/__name__.js
+++ b/blueprints/jsonapi-adapter/files/__root__/__path__/__name__.js
@@ -1,17 +1,5 @@
 <%= importStatement %>
-import config from '../config/environment';
 
 export default <%= baseClass %>.extend({
   type: '<%= entity %>',
-
-  url: config.APP.API_PATH + '/<%= resource %>',
-
-  /*fetchUrl: function(url) {
-    const proxy = config.APP.API_HOST_PROXY;
-    const host = config.APP.API_HOST;
-    if (proxy && host) {
-      url = url.replace(proxy, host);
-    }
-    return url;
-  }*/
 });

--- a/tests/acceptance/polymorphic-test.js
+++ b/tests/acceptance/polymorphic-test.js
@@ -9,6 +9,8 @@ import pictures1ImageableMock from 'fixtures/api/pictures/1/imageable';
 import pictures5Mock from 'fixtures/api/pictures/5';
 import pictures5ImageableMock from 'fixtures/api/pictures/5/imageable';
 
+import config from '../../config/environment';
+
 module('Acceptance | polymorphic', {
   beforeEach: function() {
     this.sandbox = window.sinon.sandbox.create();
@@ -23,7 +25,7 @@ module('Acceptance | polymorphic', {
 
 test('visiting /pictures list', function(assert) {
   assert.expect(6);
-  setupFetchResonses(this.sandbox);
+  setupFetchResponses(this.sandbox);
 
   visit('/pictures');
   andThen(function() {
@@ -39,7 +41,7 @@ test('visiting /pictures list', function(assert) {
 
 test('visiting /pictures/1, picture with an (imageable) product relation', function(assert) {
   assert.expect(3);
-  setupFetchResonses(this.sandbox);
+  setupFetchResponses(this.sandbox);
 
   visit('/pictures/1');
   andThen(function() {
@@ -54,7 +56,7 @@ test('visiting /pictures/1, picture with an (imageable) product relation', funct
 
 test('visiting /pictures/5, picture with an (imageable) employee relation', function(assert) {
   assert.expect(3);
-  setupFetchResonses(this.sandbox);
+  setupFetchResponses(this.sandbox);
 
   visit('/pictures/5');
   andThen(function() {
@@ -68,27 +70,28 @@ test('visiting /pictures/5, picture with an (imageable) employee relation', func
 });
 
 
-function setupFetchResonses(sandbox) {
+function setupFetchResponses(sandbox) {
+  const apiUrl = [config.APP.API_HOST, config.APP.API_PATH].join('/');
   sandbox.stub(window, 'fetch', function (url) {
     let resp;
     switch(url) {
-      case 'api/v1/pictures?sort=id&include=imageable':
+      case [apiUrl, 'pictures?sort=id&include=imageable'].join('/'):
         resp = picturesMockResponse();
         break;
-      case 'api/v1/pictures/1':
+      case [apiUrl, 'pictures/1'].join('/'):
         resp = pictures1MockResponse();
         break;
-      case '/api/v1/pictures/1/imageable':
+      case [apiUrl, 'pictures/1/imageable'].join('/'):
         resp = pictures1ImageableMockResponse();
         break;
-      case 'api/v1/pictures/5':
+      case [apiUrl, 'pictures/5'].join('/'):
         resp = pictures5MockResponse();
         break;
-      case '/api/v1/pictures/5/imageable':
+      case [apiUrl, 'pictures/5/imageable'].join('/'):
         resp = pictures5ImageableMockResponse();
         break;
       default:
-        throw('no mocked fetch reponse for request');
+        throw('no mocked fetch reponse for request: ' + url);
     }
     return resp;
   });

--- a/tests/dummy/app/adapters/author.js
+++ b/tests/dummy/app/adapters/author.js
@@ -1,17 +1,5 @@
 import ApplicationAdapter from './application';
-import config from '../config/environment';
 
 export default ApplicationAdapter.extend({
-  type: 'author',
-
-  url: config.APP.API_PATH + '/authors',
-
-  fetchUrl: function(url) {
-    const proxy = config.APP.API_HOST_PROXY;
-    const host = config.APP.API_HOST;
-    if (proxy && host) {
-      url = url.replace(proxy, host);
-    }
-    return url;
-  }
+  type: 'author'
 });

--- a/tests/dummy/app/adapters/comment.js
+++ b/tests/dummy/app/adapters/comment.js
@@ -1,17 +1,5 @@
 import ApplicationAdapter from './application';
-import config from '../config/environment';
 
 export default ApplicationAdapter.extend({
-  type: 'comment',
-
-  url: config.APP.API_PATH + '/comments',
-
-  fetchUrl: function(url) {
-    const proxy = config.APP.API_HOST_PROXY;
-    const host = config.APP.API_HOST;
-    if (proxy && host) {
-      url = url.replace(proxy, host);
-    }
-    return url;
-  }
+  type: 'comment'
 });

--- a/tests/dummy/app/adapters/commenter.js
+++ b/tests/dummy/app/adapters/commenter.js
@@ -1,17 +1,5 @@
 import ApplicationAdapter from './application';
-import config from '../config/environment';
 
 export default ApplicationAdapter.extend({
-  type: 'commenter',
-
-  url: config.APP.API_PATH + '/commenters',
-
-  fetchUrl: function(url) {
-    const proxy = config.APP.API_HOST_PROXY;
-    const host = config.APP.API_HOST;
-    if (proxy && host) {
-      url = url.replace(proxy, host);
-    }
-    return url;
-  }
+  type: 'commenter'
 });

--- a/tests/dummy/app/adapters/employee.js
+++ b/tests/dummy/app/adapters/employee.js
@@ -1,17 +1,5 @@
 import ApplicationAdapter from './application';
-import config from '../config/environment';
 
 export default ApplicationAdapter.extend({
-  type: 'employee',
-
-  url: config.APP.API_PATH + '/employees',
-
-  fetchUrl: function(url) {
-    const proxy = config.APP.API_HOST_PROXY;
-    const host = config.APP.API_HOST;
-    if (proxy && host) {
-      url = url.replace(proxy, host);
-    }
-    return url;
-  }
+  type: 'employee'
 });

--- a/tests/dummy/app/adapters/imageable.js
+++ b/tests/dummy/app/adapters/imageable.js
@@ -1,20 +1,9 @@
 import ApplicationAdapter from './application';
-import config from '../config/environment';
-//import { pluralize } from 'ember-inflector';
 
 export default ApplicationAdapter.extend({
   type: 'imageable',
 
   url: null,
-
-  fetchUrl: function(url) {
-    const proxy = config.APP.API_HOST_PROXY;
-    const host = config.APP.API_HOST;
-    if (proxy && host) {
-      url = url.replace(proxy, host);
-    }
-    return url;
-  },
 
   find() {},
   findOne() {},

--- a/tests/dummy/app/adapters/picture.js
+++ b/tests/dummy/app/adapters/picture.js
@@ -1,17 +1,5 @@
 import ApplicationAdapter from './application';
-import config from '../config/environment';
 
 export default ApplicationAdapter.extend({
-  type: 'picture',
-
-  url: config.APP.API_PATH + '/pictures',
-
-  fetchUrl: function(url) {
-    const proxy = config.APP.API_HOST_PROXY;
-    const host = config.APP.API_HOST;
-    if (proxy && host) {
-      url = url.replace(proxy, host);
-    }
-    return url;
-  }
+  type: 'picture'
 });

--- a/tests/dummy/app/adapters/post.js
+++ b/tests/dummy/app/adapters/post.js
@@ -1,18 +1,6 @@
 import ApplicationAdapter from './application';
-import config from '../config/environment';
 import AuthorizationMixin from '../mixins/authorization';
 
 export default ApplicationAdapter.extend(AuthorizationMixin, {
-  type: 'post',
-
-  url: config.APP.API_PATH + '/posts',
-
-  fetchUrl: function(url) {
-    const proxy = config.APP.API_HOST_PROXY;
-    const host = config.APP.API_HOST;
-    if (proxy && host) {
-      url = url.replace(proxy, host);
-    }
-    return url;
-  }
+  type: 'post'
 });

--- a/tests/dummy/app/adapters/product.js
+++ b/tests/dummy/app/adapters/product.js
@@ -1,17 +1,5 @@
 import ApplicationAdapter from './application';
-import config from '../config/environment';
 
 export default ApplicationAdapter.extend({
-  type: 'product',
-
-  url: config.APP.API_PATH + '/products',
-
-  fetchUrl: function(url) {
-    const proxy = config.APP.API_HOST_PROXY;
-    const host = config.APP.API_HOST;
-    if (proxy && host) {
-      url = url.replace(proxy, host);
-    }
-    return url;
-  }
+  type: 'product'
 });

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -17,8 +17,7 @@ module.exports = function(environment) {
     APP: {
       // Here you can pass flags/options to your application instance
       // when it is created
-      API_HOST: '/',
-      API_HOST_PROXY: 'http://api.pixelhandler.com/',
+      API_HOST: 'http://api.pixelhandler.com',
       API_PATH: 'api/v1',
     },
     contentSecurityPolicy: {

--- a/tests/unit/adapters/application-test.js
+++ b/tests/unit/adapters/application-test.js
@@ -28,6 +28,35 @@ moduleFor('adapter:application', 'Unit | Adapter | application', {
   }
 });
 
+test('adapter has sane default url', function (assert) {
+  assert.expect(1);
+  this.registry.register('config:environment', {
+    APP: {
+      API_HOST: 'http://api.pixelhandler.com',
+      API_PATH: 'api/v1'
+    }
+  });
+  const adapter = this.subject({type: 'posts'});
+  assert.equal(adapter.get('url'), 'http://api.pixelhandler.com/api/v1/posts');
+});
+
+test('adapter default url handles enclosing slashes in config', function (assert) {
+  assert.expect(1);
+  this.registry.register('config:environment', {
+    APP: {
+      API_HOST: 'http://api.pixelhandler.com/',
+      API_PATH: '/api/v1/'
+    }
+  });
+  const adapter = this.subject({type: 'posts'});
+  assert.equal(adapter.get('url'), 'http://api.pixelhandler.com/api/v1/posts');
+});
+
+test('adapter allows custom url', function (assert) {
+  const adapter = this.subject({type: 'posts', url: 'http://example.com/posts'});
+  assert.equal(adapter.get('url'), 'http://example.com/posts');
+});
+
 test('#find calls #findOne when options arg is a string', function(assert) {
   assert.expect(3);
   const done = assert.async();


### PR DESCRIPTION
@pixelhandler:
I think the `API_HOST_PROXY` stuff does not belong in this library. 

In your [blogpost](https://pixelhandler.com/posts/my-battle-with-data-persistence-in-ember-apps) you write "Unless you really want to use CORs (cross-origin resource sharing)."

I believe CORS _is_ the default, and setting up proxy's to circumvent Same Origin Policy is the odd setup. Even in development setups it is much easier to set up CORS than to set up some weird proxy that handles requests on some path of your frontend-application. Same Origin Policy is even in play when connecting to a different port on the same host.

I for one was quite confused by the presence of the settings/option in the config, documentation and blueprint-generated adapters. It took thinking and work to actually set up the urls for my adapters, with or without the proxy. Which is totally unnecessary IMHO.

I'm all for keeping some mention of this setup in the docs, in a list of Tips & Tricks or something. But I firmly believe the proxied setup is an exception/edge-case that regular users should not have to deal with.

Also, this simplified the basic setup of the `url` property, which is hereby set up to a sane default using `config.APP.API_HOST` and `config.APP.API_PATH` and it's type attribute. And can of course be overridden. Please have a look and let me know what you think.
